### PR TITLE
iglu r7 title fix

### DIFF
--- a/_posts/2017-12-27-iglu-r7-treskilling-yellow-released/index.md
+++ b/_posts/2017-12-27-iglu-r7-treskilling-yellow-released/index.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Iglu 7 Treskilling Yellow released
-title-short: Iglu 7 Treskilling Yellow
+title: Iglu R7 Treskilling Yellow released
+title-short: Iglu R7 Treskilling Yellow
 tags: [iglu, json, json schema, redshift]
 author: Oguzhan
 category: Releases


### PR DESCRIPTION
fixed blog post title to include "R" as per previous release naming conventions