### PR TITLE
Power blog posts with Discourse comments

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -28,7 +28,7 @@
 
 								<script type="text/javascript">
 								  DiscourseEmbed = { discourseUrl: 'https://discourse.snowplowanalytics.com/',
-								                     discourseEmbedUrl: 'https://qa.snowplowanalytics.com{{ page.permalink }}' }; 
+								                     discourseEmbedUrl: 'https://snowplowanalytics.com{{ page.permalink }}' }; 
 
 								  (function() {
 								    var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -41,10 +41,7 @@
 							</div>
 						</div>
 						<div class="row spacer-bottom-20">
-							<div class="qa col-xs-12 col-sm-6">
-								<h5>Thoughts or questions?<br/>Come join us in our <a href="http://discourse.snowplowanalytics.com" target="_blank">Discourse forum</a>!</h5>
-							</div>
-							<div class="col-xs-12 col-sm-6 text-right text-sm-left text-xs-left">
+							<div class="col-md-8">
 					        	<div class="social">
 					        		<span class="social-label">Share</span>
 					        		<div class="social-buttons"></div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,6 +21,26 @@
 
 					<div class="post-footer">
 						<div class="row spacer-bottom-20">
+							<div class="col-xs-12 col-sm-12">
+								{% if page.discourse == true %}
+								
+								<div id='discourse-comments'></div>
+
+								<script type="text/javascript">
+								  DiscourseEmbed = { discourseUrl: 'https://discourse.snowplowanalytics.com/',
+								                     discourseEmbedUrl: 'https://snowplowanalytics.com{{ page.permalink }}' }; 
+
+								  (function() {
+								    var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
+								    d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+								    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+								  })();
+								</script>
+
+								{% endif %}
+							</div>
+						</div>
+						<div class="row spacer-bottom-20">
 							<div class="qa col-xs-12 col-sm-6">
 								<h5>Thoughts or questions?<br/>Come join us in our <a href="http://discourse.snowplowanalytics.com" target="_blank">Discourse forum</a>!</h5>
 							</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -28,7 +28,7 @@
 
 								<script type="text/javascript">
 								  DiscourseEmbed = { discourseUrl: 'https://discourse.snowplowanalytics.com/',
-								                     discourseEmbedUrl: 'https://snowplowanalytics.com{{ page.permalink }}' }; 
+								                     discourseEmbedUrl: 'https://qa.snowplowanalytics.com{{ page.permalink }}' }; 
 
 								  (function() {
 								    var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;


### PR DESCRIPTION
This pull request will create the possibility of embedding Discourse comments on blog posts.

The comments won’t work on next.snowplowanalytics.com because the embed script is written for snowplowanalytics.com.

Don’t forget that for the comments to show up you need to place “discourse: true” on the front matter.

#214 

