### PR TITLE
Blog - Duplicate Category

### DIFF
--- a/_posts/2013-01-20-snowplow-hits-202-stars/index.md
+++ b/_posts/2013-01-20-snowplow-hits-202-stars/index.md
@@ -3,7 +3,7 @@ layout: post
 title: Snowplow reaches 202 stars on GitHub
 tags: [snowplow, github, scala]
 author: Alex
-category: Inside the plow
+category: Inside the Plow
 permalink: /blog/2013/01/20/snowplow-hits-202-stars/
 ---
 

--- a/_posts/2013-09-27-how-much-does-snowplow-cost-to-run/index.md
+++ b/_posts/2013-09-27-how-much-does-snowplow-cost-to-run/index.md
@@ -4,7 +4,7 @@ title: How much does Snowplow cost to run?
 title-short: How much does Snowplow cost to run
 tags: [snowplow, total cost of ownership]
 author: Yali
-category: Inside the Plow  
+category: Inside the Plow
 permalink: /blog/2013/09/27/how-much-does-snowplow-cost-to-run/
 ---
 


### PR DESCRIPTION
This PR removes the duplicate category “Inside the Plow” in the Blog sidebar menu. #626 